### PR TITLE
Add input-rodne-cislo component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,38 @@ examples/**/package-lock.json
 *.zip
 sassdoc/
 .idea/
+
+.vscode
+
+
+### https://raw.github.com/github/gitignore/7792e50daeaa6c07460484704671d1dc9f0045a7/Global/macOS.gitignore
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+

--- a/src/all.js
+++ b/src/all.js
@@ -11,6 +11,7 @@ import Tabs from './components/tabs/tabs'
 import SdnHeader from './components/_custom/header/header'
 import SdnTimeline from './components/_custom/timeline/timeline'
 import SdnAppearLink from './utilities/appear-link/appear-link'
+import SdnInputRodneCislo from './components/_custom/input-rodne-cislo/intput-rodne-cislo'
 
 function initAll (options) {
   // Set the options to an empty object by default if no options are passed.
@@ -73,6 +74,11 @@ function initAll (options) {
   nodeListForEach($appearLinks, function ($link) {
     new SdnAppearLink($link).init()
   })
+  var $inputsRodneCislo = document.querySelectorAll('[data-module="sdn-input-rodne-cislo"]')
+  nodeListForEach($inputsRodneCislo, function ($inputRodneCislo) {
+    new SdnInputRodneCislo($inputRodneCislo).init()
+  })
+  
 }
 
 export {
@@ -87,5 +93,6 @@ export {
   Radios,
   Tabs,
   SdnHeader,
-  SdnTimeline
+  SdnTimeline,
+  SdnInputRodneCislo
 }

--- a/src/components/_custom/_all.scss
+++ b/src/components/_custom/_all.scss
@@ -10,3 +10,4 @@
 @import "phase-banner/phase-banner";
 @import "hero/hero";
 @import "thumbnail/thumbnail";
+@import "input-rodne-cislo/input-rodne-cislo";

--- a/src/components/_custom/input-rodne-cislo/README.md
+++ b/src/components/_custom/input-rodne-cislo/README.md
@@ -1,0 +1,15 @@
+# Input Rodne Cislo
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the input component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/text-input).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/text-input/#options-example-default) for details.

--- a/src/components/_custom/input-rodne-cislo/_input-rodne-cislo.scss
+++ b/src/components/_custom/input-rodne-cislo/_input-rodne-cislo.scss
@@ -1,0 +1,75 @@
+@import "../../../settings/all";
+@import "../../../tools/all";
+@import "../../../helpers/all";
+
+@import "../../error-message/error-message";
+@import "../../hint/hint";
+@import "../../label/label";
+
+@include govuk-exports("govuk/component/input") {
+  .govuk-input {
+    @include govuk-font($size: 19);
+    @include govuk-focusable;
+
+    box-sizing: border-box;
+    width: 100%;
+    height: 40px;
+    margin-top: 0;
+
+    padding: govuk-spacing(1);
+    // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
+    // as background-color and color need to always be set together, color should not be set either
+    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+    border-radius: 0;
+
+    // Disable inner shadow and remove rounded corners
+    appearance: none;
+  }
+
+  .govuk-input::-webkit-outer-spin-button,
+  .govuk-input::-webkit-inner-spin-button {
+    margin: 0;
+    -webkit-appearance: none;
+  }
+
+  .govuk-input[type="number"] {
+    -moz-appearance: textfield;
+  }
+
+  .govuk-input--error {
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+  }
+
+  // The ex measurements are based on the number of W's that can fit inside the input
+  // Extra space is left on the right hand side to allow for the Safari prefill icon
+  // Linear regression estimation based on visual tests: y = 1.76 + 1.81x
+
+  .govuk-input--width-30 {
+    max-width: 56ex + 3ex;
+  }
+
+  .govuk-input--width-20 {
+    max-width: 38ex + 3ex;
+  }
+
+  .govuk-input--width-10 {
+    max-width: 20ex + 3ex;
+  }
+
+  .govuk-input--width-5 {
+    max-width: 10.8ex;
+  }
+
+  .govuk-input--width-4 {
+    max-width: 9ex;
+  }
+
+  .govuk-input--width-3 {
+    max-width: 7.2ex;
+  }
+
+  .govuk-input--width-2 {
+    max-width: 5.4ex;
+  }
+
+}

--- a/src/components/_custom/input-rodne-cislo/input-rodne-cislo-parse.js
+++ b/src/components/_custom/input-rodne-cislo/input-rodne-cislo-parse.js
@@ -1,0 +1,118 @@
+const SUFFIX_CHANGE_YEAR = 54; // 1954
+const FEMALE_MONTH_OFFSET = 50;
+
+function parseYear(strYear, strSuffixLength) {
+  const intYear = parseInt(strYear);
+
+  if (isNaN(intYear)) {
+    throw new Error("Rok nie je číslo");
+  }
+
+  let year = null;
+  if (intYear >= SUFFIX_CHANGE_YEAR) {
+    year = 19 * 100 + intYear;
+  } else {
+    let century = null;
+    if (strSuffixLength == 3) {
+      century = 19;
+    } else if (strSuffixLength == 4) {
+      century = 20;
+    }
+    year = century * 100 + intYear;
+  }
+  return year;
+}
+
+function parseMonthAndSex(strMonth) {
+  const intMonth = parseInt(strMonth);
+  let month = null;
+  let sex = null;
+  if (intMonth > FEMALE_MONTH_OFFSET) {
+    month = intMonth - FEMALE_MONTH_OFFSET;
+    sex = "female";
+  } else {
+    month = intMonth;
+    sex = "male";
+  }
+
+  if (month < 1 || 12 < month) {
+    throw new Error("Mesiac nie je v intervale 1-12");
+  }
+  return { month, sex };
+}
+
+function checkDate(year, month, day){
+
+  const date = new Date(year, month, day);
+  const isValidDate = date instanceof Date && !isNaN(date);
+  if (!isValidDate) {
+    throw new Error("Dátum narodenia nie je existujúci dátum");
+  }
+}
+
+function parseDay(strDay) {
+  const day = parseInt(strDay);
+  if (day < 1 || 31 < day) {
+    throw new Error("Deň nie je v intervale 1-31");
+  }
+  return day;
+}
+
+function checksum(onlyDigits, strSuffixLength){
+
+  if (strSuffixLength == 4) {
+    const number = parseInt(onlyDigits);
+    if (number % 11 !== 0) {
+      // throw new Error("Kontrolný súčet nesedí" + ` ${Math.ceil(number / 11) * 11}`);
+      throw new Error("Kontrolný súčet nesedí");
+    }
+  }
+}
+
+export function parseRC(strRodneCislo) {
+  const regexpRC = /^(\d{2})(\d{2})(\d{2})(\d{3,4})$/g;
+  const onlyDigits = strRodneCislo.replace(/\D/g, "");
+  const regexpResult = regexpRC.exec(onlyDigits);
+
+  if (regexpResult === null) {
+    throw new Error("Toto nie je rodné číslo");
+  }
+
+  const [_, strYear, strMonth, strDay, strSuffix] = regexpResult;
+
+  const year = parseYear(strYear, strSuffix.length);
+
+  /* 
+  Month & sex
+  */
+
+  const { month, sex } = parseMonthAndSex(strMonth);
+
+  const day = parseDay(strDay);
+
+  checkDate(year, month, day)
+
+  /*
+  Checksum
+  */
+ checksum(onlyDigits, strSuffix.length);
+
+  return {
+    year,
+    month,
+    day,
+    // date,
+    sex,
+    suffix: strSuffix
+  };
+}
+
+export function isValidRC(strRodneCislo) {
+  try {
+    parseRC(strRodneCislo);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+

--- a/src/components/_custom/input-rodne-cislo/input-rodne-cislo-parse.test.js
+++ b/src/components/_custom/input-rodne-cislo/input-rodne-cislo-parse.test.js
@@ -1,0 +1,188 @@
+/*
+
+§ 2 Rodné číslo
+(1)
+Rodné číslo je trvalý identifikačný osobný údaj fyzickej osoby (ďalej len osoba), ktorý zabezpečuje jej jednoznačnosť v informačných systémoch.1)
+(2)
+Rodné číslo sa tvorí z dátumu narodenia osoby a z koncovky, ktorá je rozlišujúcim znakom osôb narodených v tom istom kalendárnom dni.
+(3)
+Prvé dvojčíslie rodného čísla vyjadruje posledné dve číslice roku narodenia osoby, druhé dvojčíslie vyjadruje číselné označenie mesiaca narodenia osoby (u žien zvýšené o 50), tretie dvojčíslie vyjadruje číselné označenie dňa narodenia osoby v danom kalendárnom mesiaci.
+(4)
+Rodné číslo pridelené osobe narodenej do 31. decembra 1953 je deväťmiestne s trojmiestnou koncovkou.
+(5)
+Rodné číslo pridelené osobe narodenej po 1. januári 1954 je desaťmiestne so štvormiestnou koncovkou; pritom celé desaťmiestne rodné číslo musí byť bezo zvyšku deliteľné číslom 11
+
+
+avsak: https://webdev.zaujimave.info/generator-rodneho-cisla/
+- ak bolo RC udelovane po 1954 aj ked sa clovek narodil pred 1954 tak dostane 4 miestny suffix (kontrolnu cifru) - takze nevies rozlisit kedy bol clovek narodeny
+- existuje vynimka z delitelnosti 11 ak ma cislo bez kontrolnej cifry zvysok po deleni 11 = 10 tak moze byt kontrolna cifra 0
+*/
+
+// const { parseRC } = require("./input-rodne-cislo-parse");
+import { parseRC } from "./input-rodne-cislo-parse";
+
+const validInputsBefore1954 = [
+  [
+    "530101/123",
+    {
+      year: 1953,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "123"
+    }
+  ],
+  [
+    "530101123",
+    {
+      year: 1953,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "123"
+    }
+  ],
+  [
+    "535101123",
+    {
+      year: 1953,
+      month: 1,
+      day: 1,
+      sex: "female",
+      suffix: "123"
+    }
+  ]
+];
+
+const validInputsAfter1954 = [
+  [
+    "540101/1242",
+    {
+      year: 1954,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "1242"
+    }
+  ],
+  [
+    "545101/1236",
+    {
+      year: 1954,
+      month: 1,
+      day: 1,
+      sex: "female",
+      suffix: "1236"
+    }
+  ],
+  [
+    "5401011242",
+    {
+      year: 1954,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "1242"
+    }
+  ],
+  [
+    "5451011247",
+    {
+      year: 1954,
+      month: 1,
+      day: 1,
+      sex: "female",
+      suffix: "1247"
+    }
+  ]
+];
+
+const validInputsAfter2000 = [
+  [
+    "000101/1252",
+    {
+      year: 2000,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "1252"
+    }
+  ],
+
+  [
+    "530101/1243",
+    {
+      year: 2053,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "1243"
+    }
+  ],
+  [
+    "535101/1237",
+    {
+      year: 2053,
+      month: 1,
+      day: 1,
+      sex: "female",
+      suffix: "1237"
+    }
+  ],
+  [
+    "5301011243",
+    {
+      year: 2053,
+      month: 1,
+      day: 1,
+      sex: "male",
+      suffix: "1243"
+    }
+  ],
+  [
+    "5351011237",
+    {
+      year: 2053,
+      month: 1,
+      day: 1,
+      sex: "female",
+      suffix: "1237"
+    }
+  ]
+];
+
+const invalidInputs = [
+  ["000101/1251"],
+  ["539101/1243"],
+  ["535101/12"],
+  ["530132240"],
+  ["0000000000"],
+  ["012312000000000123231"]
+];
+
+describe("input-rodne-cislo", () => {
+  it.each(validInputsBefore1954)(
+    "valid input before 1954 %s",
+    (rodneCislo, expected) => {
+      expect(parseRC(rodneCislo)).toMatchObject(expected);
+    }
+  );
+
+  it.each(validInputsAfter1954)(
+    "valid input after 1954 %s",
+    (rodneCislo, expected) => {
+      expect(parseRC(rodneCislo)).toMatchObject(expected);
+    }
+  );
+
+  it.each(validInputsAfter2000)(
+    "valid input after 2000 %s",
+    (rodneCislo, expected) => {
+      expect(parseRC(rodneCislo)).toMatchObject(expected);
+    }
+  );
+
+  it.each(invalidInputs)("invalid input %s", rodneCislo => {
+    expect(() => parseRC(rodneCislo)).toThrow();
+  });
+});

--- a/src/components/_custom/input-rodne-cislo/input-rodne-cislo.yaml
+++ b/src/components/_custom/input-rodne-cislo/input-rodne-cislo.yaml
@@ -1,0 +1,176 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: The id of the input.
+- name: name
+  type: string
+  required: true
+  description: The name of the input, which is submitted with the form data.
+- name: type
+  type: string
+  required: false
+  description: Type of input control to render. Defaults to "text".
+- name: value
+  type: string
+  required: false
+  description: Optional initial value of the input.
+- name: label
+  type: object
+  required: true
+  description: Options for the label component.
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component.
+  isComponent: true
+- name: formGroup
+  type: object
+  required: false
+  description: Options for the form-group wrapper
+  params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the form group (e.g. to show error state for the whole group)
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the input.
+- name: autocomplete
+  type: string
+  required: false
+  description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+- name: pattern
+  type: string
+  required: false
+  description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
+examples:
+  - name: default
+    data:
+      label:
+        text: National Insurance number
+      id: input-example
+      name: test-name
+  - name: with hint text
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-with-hint-text
+      name: test-name-2
+  - name: with error message
+    data:
+      label:
+        text: National Insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-with-error-message
+      name: test-name-3
+      errorMessage:
+        text: Error message goes here
+  - name: with width-2 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-2
+      name: test-width-2
+      classes: govuk-input--width-2
+  - name: with width-3 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-3
+      name: test-width-3
+      classes: govuk-input--width-3
+  - name: with width-4 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-4
+      name: test-width-4
+      classes: govuk-input--width-4
+  - name: with width-5 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-5
+      name: test-width-5
+      classes: govuk-input--width-5
+  - name: with width-10 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-10
+      name: test-width-10
+      classes: govuk-input--width-10
+  - name: with width-20 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-20
+      name: test-width-20
+      classes: govuk-input--width-20
+  - name: with width-30 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-30
+      name: test-width-30
+      classes: govuk-input--width-30
+  - name: with label as page heading
+    data:
+      label:
+        text: National Insurance number
+        isPageHeading: true
+      id: input-with-page-heading
+      name: test-name
+  - name: with optional form-group classes
+    data:
+      label:
+        text: National Insurance number
+      id: input-example
+      name: test-name
+      formGroup:
+        classes: extra-class
+  - name: with autocomplete attribute
+    data:
+      label:
+        text: Postcode
+      id: input-with-autocomplete-attribute
+      name: postcode
+      autocomplete: postal-code
+  - name: with pattern attribute
+    data:
+      label:
+        text: Numbers only
+      id: input-with-pattern-attribute
+      name: numbers-only
+      type: number
+      pattern: '[0-9]*'

--- a/src/components/_custom/input-rodne-cislo/intput-rodne-cislo.js
+++ b/src/components/_custom/input-rodne-cislo/intput-rodne-cislo.js
@@ -1,0 +1,32 @@
+import { nodeListForEach } from "../../../common";
+import "../../../vendor/polyfills/Function/prototype/bind";
+import "../../../vendor/polyfills/Element/prototype/classList";
+import {parseRC, isValidRC} from "./input-rodne-cislo-parse"
+
+function SdnInputRodneCislo($module) {
+  this.$module = $module;
+  this.$input = $module.querySelector('input');
+  this.$hint = $module.querySelector('.sdn-input-rodne-cislo-hint');
+  this.onChange = this.onChange.bind(this)
+}
+
+SdnInputRodneCislo.prototype.init = function() {
+  
+  this.$input.addEventListener("input", this.onChange);
+};
+
+SdnInputRodneCislo.prototype.onChange = function(event) {
+  var target = event.target;
+  try {
+    const info = parseRC(target.value)
+    let born = 'Narodený';
+    if (info.sex == 'female'){
+      born = 'Narodená'
+    }
+    this.$hint.innerText = `${born} ${info.day}. ${info.month}. ${info.year}.`;
+  } catch(e){
+    this.$hint.innerText = e.message;
+  }
+};
+
+export default SdnInputRodneCislo;

--- a/src/components/_custom/input-rodne-cislo/macro.njk
+++ b/src/components/_custom/input-rodne-cislo/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukInputRodneCislo(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/_custom/input-rodne-cislo/template.njk
+++ b/src/components/_custom/input-rodne-cislo/template.njk
@@ -1,0 +1,49 @@
+{% from "../../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../../hint/macro.njk" import govukHint %}
+{% from "../../label/macro.njk" import govukLabel %}
+{% from "../../input/macro.njk" import govukInput %}
+
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
+{% set describedBy = "" %}
+<div  data-module="sdn-input-rodne-cislo" class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+
+  <span class="govuk-hint sdn-input-rodne-cislo-hint"></span>
+  <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+  {%- if params.value %} value="{{ params.value}}"{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
+  {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+</div>


### PR DESCRIPTION
V podstate to je normalny text input, avsak pridava hint, po ktorom si pouzivatel moze skontrolovat rodne cislo.

Zvolil som hint a nie error pretoze:
- rodne cisla vydavane s 4 cifernou koncovkou od roku 1954 ale ak ste clovek narodeny pred 1954 ale s rodnym cislom pridelenym po '54 dostanete 4 cifernu koncovku, takze nevieme urcit rok narodenia
- existuje vynimka z delitelnosti 11 ak ma cislo bez kontrolnej cifry zvysok po deleni 11 = 10 tak moze byt kontrolna cifra 0 (nie je mi jasne preco, na internete sa udava ze priblizne 1000 takychto RC bolo vydanych)
- verim, ze su este nejake ine problematicke miesta s RC

Resolves https://github.com/slovensko-digital/navody-frontend/issues/101

A takto nejako to vyzera (label sa da menit):

![image](https://user-images.githubusercontent.com/1194439/60724030-a31a3e80-9f35-11e9-9d5a-983be038dbeb.png)
![image](https://user-images.githubusercontent.com/1194439/60724045-aca3a680-9f35-11e9-8a19-7b009afc71ee.png)
![image](https://user-images.githubusercontent.com/1194439/60724078-c349fd80-9f35-11e9-971b-31428f85b36e.png)
![image](https://user-images.githubusercontent.com/1194439/60724082-c80eb180-9f35-11e9-8328-6e8014d69576.png)
![image](https://user-images.githubusercontent.com/1194439/60724092-ce049280-9f35-11e9-8129-48b89bb35384.png)
![image](https://user-images.githubusercontent.com/1194439/60724106-d52ba080-9f35-11e9-96ce-f3e058f65d6f.png)
![image](https://user-images.githubusercontent.com/1194439/60724125-e4125300-9f35-11e9-983d-339bd7752be6.png)
![image](https://user-images.githubusercontent.com/1194439/60724140-e96f9d80-9f35-11e9-8ba8-9a7d03735fc1.png)
