### PR TITLE
Zmena gradientu na pozadí pri searchbare

### DIFF
--- a/src/govuk/components/_custom/searchbar/_searchbar.scss
+++ b/src/govuk/components/_custom/searchbar/_searchbar.scss
@@ -8,7 +8,7 @@ $icon-search: url("../../../assets/images/icon-search-white.svg");
 @include govuk-exports("govuk/sdn/component/searchbar") {
   // todo replace colors from global variables
   $from: #2e3ac7;
-  $to: #2E75D9;
+  $to: #2e75d9;
   $search-block-bg: govuk-colour("white");
 
   .sdn-searchbar-wrapper {

--- a/src/govuk/components/_custom/searchbar/_searchbar.scss
+++ b/src/govuk/components/_custom/searchbar/_searchbar.scss
@@ -8,7 +8,7 @@ $icon-search: url("../../../assets/images/icon-search-white.svg");
 @include govuk-exports("govuk/sdn/component/searchbar") {
   // todo replace colors from global variables
   $from: #2e3ac7;
-  $to: #448bef;
+  $to: #2E75D9;
   $search-block-bg: govuk-colour("white");
 
   .sdn-searchbar-wrapper {


### PR DESCRIPTION
zmena gradientu kvôi čitatelnosti
Pred:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/ccd04d87-8be8-4ef5-adc6-62d6aef5bce4)
Po:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/6e4887cc-cc74-4ac1-91f1-c32556cf62e4)

Closes slovensko-digital/navody.digital#614