### PR TITLE
Zvýšenie opacity ikonky lupy v header

### DIFF
--- a/src/govuk/components/_custom/header/_header.scss
+++ b/src/govuk/components/_custom/header/_header.scss
@@ -152,7 +152,6 @@
       padding: 0;
       border: 0;
       border-radius: 3px;
-      opacity: .5;
       color: $sdn-search-button-color;
       background: $sdn-search-button-background $icon-search no-repeat center center;
       background-size: 18px 18px;


### PR DESCRIPTION
pred:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/49697271-e52a-4b07-967e-35a54f0041da)

Po:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/dfc42728-e842-4d3c-b98c-4b89ae1acc20)

Closes slovensko-digital/navody.digital#615