### PR TITLE
Oprava focusu na ikonke lupy

### DIFF
--- a/src/govuk/components/_custom/header/_header.scss
+++ b/src/govuk/components/_custom/header/_header.scss
@@ -145,21 +145,15 @@
 
     button {
       position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      width: 40px;
+      top: 2px;
+      right: 2px;
+      bottom: 2px;
       padding: 0;
       border: 0;
-      border-radius: 3px;
-      opacity: .5;
       color: $sdn-search-button-color;
       background: $sdn-search-button-background $icon-search no-repeat center center;
       background-size: 18px 18px;
 
-      &:focus {
-        outline: transparent;
-      }
     }
 
     form {


### PR DESCRIPTION
Zmena aby pri prehliadaní s tab, aby bola ikonka lupa správne focusnutá
Pred:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/13aa3f66-b831-46aa-b416-d73f6dcfd7e3)
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/b92ac237-1537-468a-834e-a08d21e651ff)

Po:
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/db48f405-e4bd-487e-a62b-e95ec480a326)
![image](https://github.com/slovensko-digital/navody-frontend/assets/72993141/0838b582-37e7-48d6-aacf-6523d31a40ab)

Closes slovensko-digital/navody.digital#617